### PR TITLE
#4 create object url media stream deprecated

### DIFF
--- a/src/components/CameraPreview/__snapshots__/index.spec.js.snap
+++ b/src/components/CameraPreview/__snapshots__/index.spec.js.snap
@@ -4,6 +4,5 @@ exports[`CameraPreview should render 1`] = `
 <video
   autoPlay={true}
   className="sc-bdVaJa fePDys"
-  src="blob://someblobl.com"
 />
 `;

--- a/src/components/CameraPreview/index.js
+++ b/src/components/CameraPreview/index.js
@@ -5,16 +5,14 @@ import styled from 'styled-components';
 const InnerCameraPreview = styled.video`
 `;
 
-const CameraPreview = ({ source, videoRef }) => (
+const CameraPreview = ({ videoRef }) => (
   <InnerCameraPreview
     autoPlay
     innerRef={(el) => { videoRef(el); }}
-    src={source}
   />
 );
 
 CameraPreview.propTypes = {
-  source: PropTypes.string.isRequired,
   videoRef: PropTypes.func.isRequired,
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ class QrCodeScanner extends Component {
   }
 
   bindVideoStream() {
-    if (typeof this.videoTag !== 'undefined') {
+    if (this.videoTag != null) {
       return (this.videoTag.srcObject = this.stream);
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ class QrCodeScanner extends Component {
     super(props);
 
     this.state = {
-      objectUrl: null,
+      streamObject: null,
     };
 
     this.bindVideoStream = this.bindVideoStream.bind(this);
@@ -45,7 +45,7 @@ class QrCodeScanner extends Component {
         .then((stream) => {
           this.stream = stream;
           this.setState(() => ({
-            objectUrl: stream,
+            streamObject: stream,
           }));
 
           raf(this.onCreateSnap);
@@ -97,7 +97,7 @@ class QrCodeScanner extends Component {
   }
 
   render() {
-    const { objectUrl, error } = this.state;
+    const { streamObject, error } = this.state;
     const { width, height, showAimAssist } = this.props;
 
     if (error) {
@@ -115,7 +115,7 @@ class QrCodeScanner extends Component {
 
     return (
       <Wrapper innerRef={(el) => { this.wrapper = el; }}>
-        {objectUrl &&
+        {streamObject &&
           <CameraWrapper
             showAimAssist={showAimAssist}
           >

--- a/src/index.js
+++ b/src/index.js
@@ -17,18 +17,19 @@ class QrCodeScanner extends Component {
     super(props);
 
     this.state = {
-      streamUrl: null,
+      objectUrl: null,
     };
 
+    this.bindVideoStream = this.bindVideoStream.bind(this);
     this.onCreateSnap = this.onCreateSnap.bind(this);
   }
 
   componentDidMount() {
     const {
       navigator,
-      URL: { createObjectURL },
     } = global.window;
     const { width, height } = this.props;
+
     if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
       const constraints = {
         audio: false,
@@ -44,7 +45,7 @@ class QrCodeScanner extends Component {
         .then((stream) => {
           this.stream = stream;
           this.setState(() => ({
-            streamUrl: createObjectURL(stream),
+            objectUrl: stream,
           }));
 
           raf(this.onCreateSnap);
@@ -53,6 +54,8 @@ class QrCodeScanner extends Component {
           this.setState(() => ({ error }));
         });
     }
+
+    raf(this.bindVideoStream);
   }
 
   componentWillUnmount() {
@@ -85,8 +88,16 @@ class QrCodeScanner extends Component {
     qr.decode(imageData);
   }
 
+  bindVideoStream() {
+    if (typeof this.videoTag !== 'undefined') {
+      return (this.videoTag.srcObject = this.stream);
+    }
+
+    return raf(this.bindVideoStream);
+  }
+
   render() {
-    const { streamUrl, error } = this.state;
+    const { objectUrl, error } = this.state;
     const { width, height, showAimAssist } = this.props;
 
     if (error) {
@@ -104,13 +115,12 @@ class QrCodeScanner extends Component {
 
     return (
       <Wrapper innerRef={(el) => { this.wrapper = el; }}>
-        {streamUrl &&
+        {objectUrl &&
           <CameraWrapper
             showAimAssist={showAimAssist}
           >
             <CameraPreview
               videoRef={(el) => { this.videoTag = el; }}
-              source={streamUrl}
             />
             <HiddenCanvas
               innerRef={(el) => { this.canvas = el; }}

--- a/src/index.js
+++ b/src/index.js
@@ -90,10 +90,11 @@ class QrCodeScanner extends Component {
 
   bindVideoStream() {
     if (this.videoTag != null) {
-      return (this.videoTag.srcObject = this.stream);
+      this.videoTag.srcObject = this.stream;
+      return;
     }
 
-    return raf(this.bindVideoStream);
+    raf(this.bindVideoStream);
   }
 
   render() {


### PR DESCRIPTION
Done a fix so that library is compliant with browsers that not longer accepts MediaStream's with URL.createObjectURL

this solves #4 